### PR TITLE
Fix callback handling exceptions

### DIFF
--- a/src/AdyenCheckoutHandler.cs
+++ b/src/AdyenCheckoutHandler.cs
@@ -7,19 +7,20 @@ using Dynamicweb.Ecommerce.Orders.Gateways;
 using Dynamicweb.Extensibility.AddIns;
 using Dynamicweb.Extensibility.Editors;
 using Dynamicweb.Frontend;
+using Dynamicweb.Logging;
 using Dynamicweb.Rendering;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 
 namespace Dynamicweb.Ecommerce.CheckoutHandlers.Adyen
 {
     [AddInName("AdyenCheckout"), AddInDescription("Adyen checkout handler"), AddInUseParameterGrouping(true)]
-    public class AdyenCheckout : CheckoutHandler, IRemoteCapture, ICancelOrder, IFullReturn, IPartialReturn, ISavedCard
+    public class AdyenCheckout : CheckoutHandler, IRemoteCapture, ICancelOrder, IFullReturn, IPartialReturn, ISavedCard, ICheckoutHandlerCallback
     {
         private static class Tags
         {
@@ -233,24 +234,8 @@ namespace Dynamicweb.Ecommerce.CheckoutHandlers.Adyen
             string action = Converter.ToString(Context.Current.Request["action"]);
             if (string.IsNullOrEmpty(action))
             {
-                try
-                {
-                    string jsonData = (string)Context.Current.Items["AdyenCallback"];
-                    if (string.IsNullOrEmpty(jsonData))
-                    {
-                        using (var inputStream = new StreamReader(Context.Current.Request.InputStream))
-                        {
-                            jsonData = inputStream.ReadToEndAsync().GetAwaiter().GetResult();
-                        }
-                    }
-
-                    Callback(order, jsonData);
-                    return ContentOutputResult.Empty;
-                }
-                finally
-                {
-                    StopProcessingOrder(originOrderId);
-                }
+                StopProcessingOrder(originOrderId);
+                return ContentOutputResult.Empty;
             }
 
             var redirectResult = Converter.ToString(Context.Current.Request["redirectResult"]);
@@ -1109,6 +1094,50 @@ namespace Dynamicweb.Ecommerce.CheckoutHandlers.Adyen
             Services.Orders.Save(order);
 
             LogEvent(order, "Saved card created: {0}", savedCard.Name);
+        }
+
+        #endregion
+
+        #region ICheckoutHandlerCallback
+
+        public static Order GetOrderFromCallback(CallbackData data)
+        {
+            var logger = LogManager.System.GetLogger(LogCategory.Health, "Checkout");
+
+            NotificationRequest request = Converter.Deserialize<NotificationRequest>(data.Body);
+
+            if (request?.NotificationItemContainers?.Count is null or 0)
+            {
+                logger.Error("Adyen notification processing: data is not found", null);
+                return null;
+            }
+
+            if (request.NotificationItemContainers.Count > 1)
+            {
+                logger.Error("The webhook notification data should contain only one NotificationRequestItem.");
+                return null;
+            }
+
+            string merchantReference = request.NotificationItemContainers[0].NotificationItem?.MerchantReference ?? "";
+            string orderId = merchantReference.IndexOf(RefundIdDelimeter, StringComparison.OrdinalIgnoreCase) is int delimeterPosition && delimeterPosition > 0
+                ? merchantReference.Substring(0, delimeterPosition)
+                : merchantReference;
+
+            Order order = Services.Orders.GetById(orderId);
+            if (order is not null)
+            {
+                var message = new StringBuilder($"Adyen notification processing: {orderId}. Json data:");
+                message.AppendLine(data.Body);
+                Services.OrderDebuggingInfos.Save(order, message.ToString(), "Order", DebuggingInfoType.Undefined);
+            }
+
+            return order;
+        }
+
+        public OutputResult HandleCallback(Order order, CallbackData data)
+        {
+            Callback(order, data.Body);
+            return ContentOutputResult.Empty;
         }
 
         #endregion

--- a/src/Dynamicweb.Ecommerce.CheckoutHandlers.Adyen.csproj
+++ b/src/Dynamicweb.Ecommerce.CheckoutHandlers.Adyen.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>10.2.1</VersionPrefix>
+    <VersionPrefix>10.7.0</VersionPrefix>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Title>Adyen</Title>
     <Description>Adyen Checkout Handler</Description>
@@ -29,8 +29,8 @@
     <None Remove="Updates\checkouthandler_error.cshtml" />
   </ItemGroup>
   <ItemGroup>
-	  <PackageReference Include="Dynamicweb.Core" Version="10.2.1" />
-	  <PackageReference Include="Dynamicweb.Ecommerce" Version="10.2.1" />
+	  <PackageReference Include="Dynamicweb.Core" Version="10.7.0" />
+	  <PackageReference Include="Dynamicweb.Ecommerce" Version="10.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Dynamicweb.Ecommerce.CheckoutHandlers.Adyen.csproj
+++ b/src/Dynamicweb.Ecommerce.CheckoutHandlers.Adyen.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>10.2.0</VersionPrefix>
+    <VersionPrefix>10.2.1</VersionPrefix>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Title>Adyen</Title>
     <Description>Adyen Checkout Handler</Description>

--- a/src/Helper.cs
+++ b/src/Helper.cs
@@ -123,7 +123,7 @@ namespace Dynamicweb.Ecommerce.CheckoutHandlers.Adyen
                 Converter.ToString(amount.Value),
                 amount.Currency,
                 notificationRequestItem.EventCode,
-                notificationRequestItem.Success.ToString().ToLower()
+                notificationRequestItem.Success.ToLower()
             };
 
             return string.Join(":", signedDataList);

--- a/src/Model/Notification/NotificationRequestItem.cs
+++ b/src/Model/Notification/NotificationRequestItem.cs
@@ -42,7 +42,7 @@ namespace Dynamicweb.Ecommerce.CheckoutHandlers.Adyen.Model.Notification
         public string Reason { get; set; }
 
         [DataMember(Name = "success")]
-        public bool Success { get; set; }
+        public string Success { get; set; }
 
         public NotificationEventCode? GetNotificationEventCode()
         {

--- a/src/Model/RequestBase.cs
+++ b/src/Model/RequestBase.cs
@@ -1,13 +1,11 @@
 ﻿using Dynamicweb.Core;
-using Dynamicweb.Core.Json.Settings;
-using System;
 using System.Runtime.Serialization;
 
 namespace Dynamicweb.Ecommerce.CheckoutHandlers.Adyen.Model
 {
     [DataContract]
     public abstract class RequestBase
-    {        
+    {
         [DataMember(Name = "merchantAccount")]
         public string MerchantAccount { get; set; }
 


### PR DESCRIPTION
We have some exceptions in the code, which occurs when we process the Adyen notifications.
This PR should fix them.

Here we used new interface ICheckoutHandlerCallback, which was implemented to handle the various provider callbacks, like Adyen webhooks. This is the PR where it was introduced: https://dev.azure.com/dynamicwebsoftware/Dynamicweb/_git/Dynamicweb10/pullrequest/13919

Using ICheckoutHandlerCallback, we can handle the Adyen webhooks without problems.

The task: https://dev.azure.com/dynamicwebsoftware/Dynamicweb/_workitems/edit/19221